### PR TITLE
The way the typecheck exception is rendered changed

### DIFF
--- a/t/07-errors.t
+++ b/t/07-errors.t
@@ -12,7 +12,6 @@ my $mm = IO::MiddleMan.hijack: $fh;
 
 throws-like { $mm.mode = 'not right' },
     Exception, 'incorrect mode must fail',
-    message => 'Type check failed in assignment to $!mode; '
-        ~ 'expected IO::MiddleMan::ValidMode but got Str';
+    message => /'Type check failed in assignment to $!mode; expected IO::MiddleMan::ValidMode but got Str'/;
 
 done-testing;


### PR DESCRIPTION
It appears that at some point the actual value of the string
was being emitted in the exception message. Changing the matcher
on message to regex should work with older rakudo where this is
not the case as well as the ones it now fails on.

Thanks.
