### PR TITLE
Fix for ```@what``` elements becoming immutable 

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl"         : "6.c",
     "name"         : "IO::MiddleMan",
-    "version"      : "1.001001",
+    "version"      : "1.001002",
     "description"  : "hijack, capture, or mute writes to an IO::Handle",
     "depends"      : [ ],
     "test-depends" : [ "Test" ],

--- a/lib/IO/MiddleMan.pm6
+++ b/lib/IO/MiddleMan.pm6
@@ -25,7 +25,7 @@ method normal  (IO::Handle $handle is rw) {
     $handle = self.bless: :$handle :mode<normal>;
 }
 
-method !process (OutputMethods $meth , *@what) returns Bool {
+method !process (OutputMethods $meth , *@what is copy) returns Bool {
     @what       = @what».gist if $meth eq 'say';
     @what[*-1] ~= $.nl-out    if $meth eq any <put say>;
     given $.mode {


### PR DESCRIPTION
It manifested in the the tests by a failure to assign to `@what[*-1]` in `!process`.

This will fix the #2 
