### PR TITLE
Add missing .close calls

### DIFF
--- a/t/02-capture.t
+++ b/t/02-capture.t
@@ -15,6 +15,8 @@ $fh.put:   |<foo bar baz>, 42;
 $fh.print: |<foo bar baz>, 42;
 $fh.print-nl;
 
+$mm.handle.close;
+
 my $out = "foobarbazgist works!42\n" # .say
             ~ "foobarbaz42\n"        # .put
             ~ "foobarbaz42"          # .print

--- a/t/04-normal.t
+++ b/t/04-normal.t
@@ -15,6 +15,8 @@ $fh.put:   |<foo bar baz>, 42;
 $fh.print: |<foo bar baz>, 42;
 $fh.print-nl;
 
+$mm.handle.close;
+
 my $out = "foobarbazgist works!42\n" # .say
             ~ "foobarbaz42\n"        # .put
             ~ "foobarbaz42"          # .print

--- a/t/05-mode-switching.t
+++ b/t/05-mode-switching.t
@@ -12,7 +12,7 @@ my $out = "foobarbazgist works!42\n" # .say
             ~ "\n",                  # .print-nl
 
 
-my $fh = $test-file-name.IO.open: :w;
+my $fh = $test-file-name.IO.open: :w, :!buffer;
 my $mm = IO::MiddleMan.hijack: $fh;
 
 subtest {

--- a/t/09-access-original-handle.t
+++ b/t/09-access-original-handle.t
@@ -14,6 +14,7 @@ $mm.handle.say:   |<foo bar baz>, TestGist.new, 42;
 $mm.handle.put:   |<foo bar baz>, 42;
 $mm.handle.print: |<foo bar baz>, 42;
 $mm.handle.print-nl;
+$mm.handle.close;
 
 my $out = "foobarbazgist works!42\n" # .say
             ~ "foobarbaz42\n"        # .put


### PR DESCRIPTION
Resolves issue #5.

Please check if this is really how it should work. For example, I expected ``$fh.close`` to do the trick also, but it doesn't. Perhaps the documentation should discuss what exactly should be .close-ed.